### PR TITLE
[test-code] Fix docker compose/flask werkzeug compat

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,4 +1,3 @@
-version: '2.1'
 services:
   service:
     build:

--- a/webinterface-Dockerfile
+++ b/webinterface-Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y curl python3 python3-pip
-RUN pip3 install requests flask==2.2.3 werkzeug gunicorn flask_mongoengine==0.9 flask_admin flask_login flask_bcrypt pyOpenSSL Flask-Markdown psutil gevent python-dateutil redis pymongo==3.12.1 Flask-Json
+RUN pip3 install requests flask==2.2.5 werkzeug==2.3.3 gunicorn flask_mongoengine==0.9 flask_admin flask_login flask_bcrypt pyOpenSSL Flask-Markdown psutil gevent python-dateutil redis pymongo==3.12.1 Flask-Json
 WORKDIR /analyzer
 ADD ./ .
 RUN python3 initializer.py --key


### PR DESCRIPTION
#### [test-code] update flask & werkzeug versions in `docker-compose-dev.yml`

After executing `docker-compose -f docker-compose-dev.yml up --build` container `website` crashes with the following error:

```
website-1       | [2024-04-15 20:29:51 +0200] [1] [INFO] Starting gunicorn 21.2.0
website-1       | [2024-04-15 20:29:51 +0200] [1] [INFO] Listening at: http://0.0.0.0:8000 (1)
website-1       | [2024-04-15 20:29:51 +0200] [1] [INFO] Using worker: gevent
website-1       | [2024-04-15 20:29:51 +0200] [7] [INFO] Booting worker with pid: 7
website-1       | [2024-04-15 20:29:52 +0200] [7] [ERROR] Exception in worker process
website-1       | Traceback (most recent call last):
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/arbiter.py", line 609, in spawn_worker
website-1       |     worker.init_process()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/ggevent.py", line 147, in init_process
website-1       |     super().init_process()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 134, in init_process
website-1       |     self.load_wsgi()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/workers/base.py", line 146, in load_wsgi
website-1       |     self.wsgi = self.app.wsgi()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/base.py", line 67, in wsgi
website-1       |     self.callable = self.load()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 58, in load
website-1       |     return self.load_wsgiapp()
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/app/wsgiapp.py", line 48, in load_wsgiapp
website-1       |     return util.import_app(self.app_uri)
website-1       |   File "/usr/local/lib/python3.10/dist-packages/gunicorn/util.py", line 371, in import_app
website-1       |     mod = importlib.import_module(module)
website-1       |   File "/usr/lib/python3.10/importlib/__init__.py", line 126, in import_module
website-1       |     return _bootstrap._gcd_import(name[level:], package, level)
website-1       |   File "<frozen importlib._bootstrap>", line 1050, in _gcd_import
website-1       |   File "<frozen importlib._bootstrap>", line 1027, in _find_and_load
website-1       |   File "<frozen importlib._bootstrap>", line 1006, in _find_and_load_unlocked
website-1       |   File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
website-1       |   File "<frozen importlib._bootstrap_external>", line 883, in exec_module
website-1       |   File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
website-1       |   File "/analyzer/web.py", line 19, in <module>
website-1       |     from flask import Flask, flash, jsonify, redirect, request, session, url_for
website-1       |   File "/usr/local/lib/python3.10/dist-packages/flask/__init__.py", line 5, in <module>
website-1       |     from .app import Flask as Flask
website-1       |   File "/usr/local/lib/python3.10/dist-packages/flask/app.py", line 30, in <module>
website-1       |     from werkzeug.urls import url_quote
website-1       | ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/dist-packages/werkzeug/urls.py)
website-1       | [2024-04-15 20:29:52 +0200] [7] [INFO] Worker exiting (pid: 7)
website-1       | [2024-04-15 20:29:52 +0200] [1] [ERROR] Worker (pid:7) exited with code 3
website-1       | [2024-04-15 20:29:52 +0200] [1] [ERROR] Shutting down: Master
website-1       | [2024-04-15 20:29:52 +0200] [1] [ERROR] Reason: Worker failed to boot.
```

Proposed change, use [`flask==2.2.5`](https://flask.palletsprojects.com/en/2.3.x/changes/#version-2-2-5) and `werkzeug==2.3.3`

```diff
--- a/webinterface-Dockerfile
+++ b/webinterface-Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y curl python3 python3-pip
-RUN pip3 install requests flask==2.2.3 werkzeug gunicorn flask_mongoengine==0.9 flask_admin flask_login flask_bcrypt pyOpenSSL Flask-Markdown psutil gevent python-dateutil redis pymongo==3.12.1 Flask-Json
+RUN pip3 install requests flask==2.2.5 werkzeug==2.3.3 gunicorn flask_mongoengine==0.9 flask_admin flask_login flask_bcrypt pyOpenSSL Flask-Markdown psutil gevent python-dateutil redis pymongo==3.12.1 Flask-Json
 WORKDIR /analyzer
 ADD ./ .
 RUN python3 initializer.py --key
```

---

#### [test-code] move to Compose Specification in `webinterface-Dockerfile`

- ref: https://github.com/compose-spec/compose-spec/blob/master/spec.md
